### PR TITLE
Improve readability and layout of compatibility questions

### DIFF
--- a/web/components/answers/compatibility-questions-display.tsx
+++ b/web/components/answers/compatibility-questions-display.tsx
@@ -367,7 +367,7 @@ function CompatibilityAnswerBlock(props: {
         'bg-canvas-0 flex-grow gap-4 whitespace-pre-line rounded-md px-3 py-2 leading-relaxed'
       }
     >
-      <Row className="text-ink-600 justify-between gap-1 text-sm">
+      <Row className="text-ink-800 justify-between gap-1 text-sm">
         {question.question}
         <Row className="gap-4">
           {comparedLover && (
@@ -409,7 +409,7 @@ function CompatibilityAnswerBlock(props: {
       </Row>
       {distinctPreferredAnswersText.length > 0 && (
         <Col className="gap-2">
-          <div className="text-ink-600 text-sm">
+          <div className="text-ink-800 text-sm">
             {preferredDoesNotIncludeAnswerText
               ? 'Acceptable'
               : 'Also acceptable'}

--- a/web/components/answers/compatibility-questions-display.tsx
+++ b/web/components/answers/compatibility-questions-display.tsx
@@ -367,9 +367,9 @@ function CompatibilityAnswerBlock(props: {
         'bg-canvas-0 flex-grow gap-4 whitespace-pre-line rounded-md px-3 py-2 leading-relaxed'
       }
     >
-      <Row className="text-ink-800 justify-between gap-1 text-sm">
+      <Row className="text-ink-800 justify-between gap-1 font-semibold">
         {question.question}
-        <Row className="gap-4">
+        <Row className="gap-4 font-normal">
           {comparedLover && (
             <div className="hidden sm:block">
               <CompatibilityDisplay
@@ -407,6 +407,11 @@ function CompatibilityAnswerBlock(props: {
       <Row className="bg-canvas-50 w-fit gap-1 rounded px-2 py-1 text-sm">
         {answerText}
       </Row>
+      <Row className="px-2 -mt-4">
+        {answer.explanation && (
+          <Linkify className="" text={answer.explanation} />
+        )}
+      </Row>
       {distinctPreferredAnswersText.length > 0 && (
         <Col className="gap-2">
           <div className="text-ink-800 text-sm">
@@ -414,7 +419,7 @@ function CompatibilityAnswerBlock(props: {
               ? 'Acceptable'
               : 'Also acceptable'}
           </div>
-          <Row className="flex-wrap gap-2">
+          <Row className="flex-wrap gap-2 -mt-2">
             {distinctPreferredAnswersText.map((text) => (
               <Row
                 key={text}
@@ -426,10 +431,8 @@ function CompatibilityAnswerBlock(props: {
           </Row>
         </Col>
       )}
-      <Col className="gap-2">
-        {answer.explanation && (
-          <Linkify className="font-semibold" text={answer.explanation} />
-        )}
+      <Col>
+
         {comparedLover && (
           <Row className="w-full justify-end sm:hidden">
             <CompatibilityDisplay


### PR DESCRIPTION
`text-ink-600` in dark mode is very hard to read in bright sunlight. Styling the questions themselves more like headings would also make skimming easier; at the same size as the *Also acceptable* label, they were quite hard to make out regardless of color.
Placing the explanation below the preferred answer is also what OkCupid does. It makes more sense to me (since the explanation is more likely to relate to a lover's preferred answer than their compromises), but it might be controversial.

Before:

![Compatibility questions original dark](https://github.com/user-attachments/assets/7b598347-5f22-4d91-9310-fb5a82cd7b28)
![Compatibility questions original light](https://github.com/user-attachments/assets/6cdd33b5-3134-46f8-ba7f-9340323928e1)

After:

![Compatibility questions restyled dark](https://github.com/user-attachments/assets/71d161c4-0b3d-40f8-8d05-fddb0671c5c8)
![Compatibility questions restyled light](https://github.com/user-attachments/assets/96987926-0263-43e2-8cca-5fb1c8d03b32)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Improved visual presentation by updating text colors, font weights, and spacing for enhanced readability.
- **New Features**
	- Added an explanation section that displays additional details when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->