### PR TITLE
Don't crash on profile pages of users without links

### DIFF
--- a/common/src/user.ts
+++ b/common/src/user.ts
@@ -13,7 +13,7 @@ export type User = {
   bio?: string
 
   // Social links
-  link: Socials
+  link?: Socials
 
   // Legacy fields (deprecated)
   /** @deprecated Use link.site instead */

--- a/web/components/lover-about.tsx
+++ b/web/components/lover-about.tsx
@@ -86,7 +86,7 @@ export default function LoverAbout(props: { lover: Lover }) {
         text={lover.is_vegetarian_or_vegan ? 'Vegetarian/Vegan' : null}
       />
       <WantsKids lover={lover} />
-      <UserHandles links={lover.user.link} />
+      <UserHandles links={lover.user.link ?? {}} />
     </Col>
   )
 }

--- a/web/components/optional-lover-form.tsx
+++ b/web/components/optional-lover-form.tsx
@@ -48,7 +48,7 @@ export const OptionalLoveUserForm = (props: {
   )
 
   const [newLinks, setNewLinks] = useState<Record<string, string | null>>(
-    user.link
+    user.link ?? {}
   )
 
   const [newLinkPlatform, setNewLinkPlatform] = useState('')


### PR DESCRIPTION
The `links` migration from #8 seems to only have been applied to users with Twitter handles, and left everyone else without the new `links` field. Accessing these profiles currently crashes the site.

This small workaround is probably a generally good idea, even after the database is fixed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of missing or undefined user links to prevent runtime errors and ensure a smoother user experience when user link information is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->